### PR TITLE
Raise HTTPError when it's necessary

### DIFF
--- a/sparkler/cmd.py
+++ b/sparkler/cmd.py
@@ -40,6 +40,7 @@ def get_commit_activity(repo):
     """
     result = []
     data = requests.get(GITHUB_STATS_URL % (repo, 'commit_activity'))
+    data.raise_for_status()
     data = data.json()
     for week in data:
         result.append(week.get('total', 0))


### PR DESCRIPTION
This commit makes sparkler raise an HTTPError when a HTTP error such as
404 NotFound error occurs. Otherwise, the error messages can be
confusing like this.

 AttributeError: 'str' object has no attribute 'get'